### PR TITLE
Fixing list of active transports while maps are switched

### DIFF
--- a/app/src/main/java/com/utyf/pmetro/map/TRP.java
+++ b/app/src/main/java/com/utyf/pmetro/map/TRP.java
@@ -68,7 +68,11 @@ public class TRP extends Parameters {
     }
 
     public static void setActive(int[] trpNums) {
-        clearActiveTRP();
+        // Do not disable transports if start station is selected
+        if (routeStart == null) {
+            clearActiveTRP();
+        }
+
         for( int tNum : trpNums ) addActive(tNum);
         synchronized (rt) {
             rt.createGraph();


### PR DESCRIPTION
Related issue: https://github.com/Utyff/pMetro/issues/6
All selected transports are preserved after map is switched in the case start of a route is selected.
