### PR TITLE
Fixed bug, when StationLabels were not loaded from .map file

### DIFF
--- a/app/src/main/java/com/utyf/pmetro/map/MAP.java
+++ b/app/src/main/java/com/utyf/pmetro/map/MAP.java
@@ -104,7 +104,7 @@ public class MAP extends Parameters {
 
         i = 1;
         stnLabels.clear();
-        if( secsNum()<i && getSec(i).name.equals("StationLabels") ) {
+        if( secsNum()>i && getSec(i).name.equals("StationLabels") ) {
             stnLabels.load(getSec(i));
             i++;
         }


### PR DESCRIPTION
StationLabels were not loaded, so they were not displayed on the map, making it difficult to distinguish metro stations from railway stations.
